### PR TITLE
Fix tests on python3.11, run tests in CI

### DIFF
--- a/.github/workflows/scc-linux.yml
+++ b/.github/workflows/scc-linux.yml
@@ -1,0 +1,28 @@
+name: SCC Linux CI
+
+on:
+  push:
+    branches:
+    - main
+    - master
+    - python3
+  pull_request:
+    branches:
+    - main
+    - master
+    - python3
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11' 
+    # Install dependencies
+    - run: pip install pytest vdf
+    # Build
+    - run: python setup.py build 
+    # Test
+    - run: python -m pytest tests

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ appimage/
 *.vdf
 .kateconfig
 
+dist/
+sccontroller.egg-info/

--- a/scc/lib/__init__.py
+++ b/scc/lib/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python2
 
-from enum import Enum, IntEnum, unique
+from .enum import Enum, IntEnum, unique

--- a/tests/test_strings/test_keys.py
+++ b/tests/test_strings/test_keys.py
@@ -1,0 +1,8 @@
+from scc.uinput import Keys
+from scc.lib import IntEnum
+
+class TestKeys(object):
+    def test_up_str(self):
+        assert isinstance(Keys.KEY_UP, IntEnum)
+        assert Keys.KEY_UP.name == "KEY_UP"
+        assert str(Keys.KEY_UP) == "Keys.KEY_UP"


### PR DESCRIPTION
The Key enum was serializing via str() incorrectly on python 3.11,  problem was a mix of usage of scc's own enum and the python stdlib enum, which changed in 3.11 (see https://github.com/python/cpython/issues/94763 )

There was only one reference to the stdlib enum so updated it to call the scc one (removing the scc specific enum.py is left for a future change, would make this one harder to review)

Added a test for Key str() and a github actions CI